### PR TITLE
feat: add getRemoteAudioTrack method for audio track visualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hamsa-ai/voice-agents-sdk",
-  "version": "0.4.1-beta.8",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hamsa-ai/voice-agents-sdk",
-      "version": "0.4.1-beta.8",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "events": "^3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hamsa-ai/voice-agents-sdk",
-  "version": "0.4.1-beta.7",
+  "version": "0.4.1-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hamsa-ai/voice-agents-sdk",
-      "version": "0.4.1-beta.7",
+      "version": "0.4.1-beta.8",
       "license": "MIT",
       "dependencies": {
         "events": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hamsa-ai/voice-agents-sdk",
-  "version": "0.4.1-beta.7",
+  "version": "0.4.1-beta.8",
   "description": "Hamsa AI - Voice Agents JavaScript SDK",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hamsa-ai/voice-agents-sdk",
-  "version": "0.4.1-beta.8",
+  "version": "0.4.1",
   "description": "Hamsa AI - Voice Agents JavaScript SDK",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1504,6 +1504,56 @@ class HamsaVoiceAgent extends EventEmitter {
   }
 
   /**
+   * Gets the remote audio track from the voice agent for visualization
+   *
+   * Provides access to the agent's audio track for use with LiveKit React
+   * visualization components like BarVisualizer. Returns undefined if not
+   * connected or no remote audio track is available.
+   *
+   * @returns RemoteTrack | undefined - The agent's audio track or undefined if not available
+   *
+   * @example With LiveKit BarVisualizer
+   * ```typescript
+   * import { BarVisualizer } from '@livekit/components-react';
+   *
+   * function AgentVisualizer({ agent }) {
+   *   const [audioTrack, setAudioTrack] = useState();
+   *
+   *   useEffect(() => {
+   *     agent.on('trackSubscribed', ({ track }) => {
+   *       if (track.kind === 'audio') {
+   *         setAudioTrack(track);
+   *       }
+   *     });
+   *   }, [agent]);
+   *
+   *   if (!audioTrack) return null;
+   *
+   *   return <BarVisualizer trackRef={{ track: audioTrack, source: 'microphone' }} />;
+   * }
+   * ```
+   */
+  getRemoteAudioTrack(): RemoteTrack | undefined {
+    const room = this.liveKitManager?.connection.getRoom();
+    if (!room?.remoteParticipants) {
+      return;
+    }
+
+    // Find the first remote participant with an audio track
+    for (const participant of room.remoteParticipants.values()) {
+      const audioPublication = Array.from(
+        participant.audioTrackPublications.values()
+      )[0];
+
+      if (audioPublication?.track) {
+        return audioPublication.track;
+      }
+    }
+
+    return;
+  }
+
+  /**
    * Delays execution for a specified amount of time.
    * @private
    * @param ms - Milliseconds to delay.
@@ -1575,6 +1625,14 @@ interface HamsaVoiceAgent {
 export { HamsaVoiceAgent, HamsaApiError };
 export default HamsaVoiceAgent;
 
+// Export LiveKit types for use with React components
+export type {
+  LocalTrack,
+  RemoteParticipant,
+  RemoteTrack,
+  RemoteTrackPublication,
+  Room,
+} from 'livekit-client';
 // Export types from LiveKitManager directly
 export type {
   AudioLevelsResult,

--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -956,6 +956,6 @@ interface HamsaVoiceAgent {
 }
 export { HamsaVoiceAgent, HamsaApiError };
 export default HamsaVoiceAgent;
-export type { LocalTrack, RemoteTrack, RemoteTrackPublication, RemoteParticipant, Room, } from 'livekit-client';
+export type { LocalTrack, RemoteParticipant, RemoteTrack, RemoteTrackPublication, Room, } from 'livekit-client';
 export type { AudioLevelsResult, CallAnalyticsResult, ConnectionStatsResult, ParticipantData, PerformanceMetricsResult, TrackStatsResult, } from './classes/livekit-manager';
 export type { HamsaVoiceAgentEvents, StartOptions, Tool, JobDetails };

--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -882,6 +882,37 @@ declare class HamsaVoiceAgent extends EventEmitter {
      * ```
      */
     getRoom(): Room | null;
+    /**
+     * Gets the remote audio track from the voice agent for visualization
+     *
+     * Provides access to the agent's audio track for use with LiveKit React
+     * visualization components like BarVisualizer. Returns undefined if not
+     * connected or no remote audio track is available.
+     *
+     * @returns RemoteTrack | undefined - The agent's audio track or undefined if not available
+     *
+     * @example With LiveKit BarVisualizer
+     * ```typescript
+     * import { BarVisualizer } from '@livekit/components-react';
+     *
+     * function AgentVisualizer({ agent }) {
+     *   const [audioTrack, setAudioTrack] = useState();
+     *
+     *   useEffect(() => {
+     *     agent.on('trackSubscribed', ({ track }) => {
+     *       if (track.kind === 'audio') {
+     *         setAudioTrack(track);
+     *       }
+     *     });
+     *   }, [agent]);
+     *
+     *   if (!audioTrack) return null;
+     *
+     *   return <BarVisualizer trackRef={{ track: audioTrack, source: 'microphone' }} />;
+     * }
+     * ```
+     */
+    getRemoteAudioTrack(): RemoteTrack | undefined;
 }
 /**
  * Declaration merging: Add type-safe event methods to HamsaVoiceAgent
@@ -925,5 +956,6 @@ interface HamsaVoiceAgent {
 }
 export { HamsaVoiceAgent, HamsaApiError };
 export default HamsaVoiceAgent;
+export type { LocalTrack, RemoteTrack, RemoteTrackPublication, RemoteParticipant, Room, } from 'livekit-client';
 export type { AudioLevelsResult, CallAnalyticsResult, ConnectionStatsResult, ParticipantData, PerformanceMetricsResult, TrackStatsResult, } from './classes/livekit-manager';
 export type { HamsaVoiceAgentEvents, StartOptions, Tool, JobDetails };


### PR DESCRIPTION
- Implemented the getRemoteAudioTrack method in HamsaVoiceAgent to retrieve the remote audio track for use with LiveKit React visualization components.
- Updated type definitions to include the new method and added detailed documentation with usage examples for better developer guidance.